### PR TITLE
feat: migrate to runtime env infra (fetcher-be & brainatlas-be)

### DIFF
--- a/brainatlas-be/Dockerfile
+++ b/brainatlas-be/Dockerfile
@@ -10,17 +10,16 @@
 #     | docker login --username AWS --password-stdin \
 #         285560394698.dkr.ecr.us-east-1.amazonaws.com
 #
-# 2. Build (no secrets needed — DATABASE_URL is supplied at runtime only):
+# 2. Build (no build args needed -- all config is runtime):
 #    NOTE: Must be run from repo root to access both brainatlas-be/ and proto/
 #   docker build \
-#     --build-arg CORS_ORIGIN \
 #     -f brainatlas-be/Dockerfile \
 #     -t 285560394698.dkr.ecr.us-east-1.amazonaws.com/capstone26t217/brainatlas-be:latest .
 #
 # 3. Push to ECR:
 #   docker push 285560394698.dkr.ecr.us-east-1.amazonaws.com/capstone26t217/brainatlas-be:latest
 #
-# 4. Run (inject secrets at runtime via --env-file or -e):
+# 4. Run (inject all config at runtime via --env-file or -e):
 #   docker run --env-file .env -p 8081:8081 \
 #     285560394698.dkr.ecr.us-east-1.amazonaws.com/capstone26t217/brainatlas-be:latest
 #
@@ -28,6 +27,10 @@
 #   docker run \
 #     -e DATABASE_URL=postgresql://... \
 #     -e CORS_ORIGIN=https://your-frontend.example.com \
+#     -e S3_ENDPOINT=http://minio:9000 \
+#     -e S3_ACCESS_KEY=... \
+#     -e S3_SECRET_KEY=... \
+#     -e S3_BUCKET=... \
 #     -p 8081:8081 \
 #     285560394698.dkr.ecr.us-east-1.amazonaws.com/capstone26t217/brainatlas-be:latest
 #
@@ -66,14 +69,9 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# All runtime vars (DATABASE_URL, CORS_ORIGIN, HTTP_ADDR) are supplied via
-# --env-file or -e at `docker run` time. Only CORS_ORIGIN and HTTP_ADDR
-# have build-time defaults as a convenience.
-ARG CORS_ORIGIN=*
-ARG HTTP_ADDR=0.0.0.0:8081
-
-ENV CORS_ORIGIN=${CORS_ORIGIN}
-ENV HTTP_ADDR=${HTTP_ADDR}
+# No ARG/ENV baking -- all config (DATABASE_URL, CORS_ORIGIN, S3_*,
+# BRAINATLAS_HTTP_ADDR, etc.) is supplied at container runtime via
+# docker-compose environment:, --env-file, or -e flags.
 
 COPY --from=builder /app/target/release/server /usr/local/bin/brainatlas-be
 

--- a/brainatlas-be/crates/infra/src/infra.rs
+++ b/brainatlas-be/crates/infra/src/infra.rs
@@ -18,9 +18,16 @@ pub struct BrainAtlasInfra {
 
 impl BrainAtlasInfra {
     pub fn new() -> Self {
-        let pg = BrainAtlasPostgresql::new();
         let env = BrainAtlasEnvInfra::new();
-        let s3 = BrainAtlasS3::new();
+
+        // Read S3 config from env once at startup
+        let s3_endpoint = env.get("S3_ENDPOINT").unwrap_or_default();
+        let s3_access_key = env.get("S3_ACCESS_KEY").unwrap_or_default();
+        let s3_secret_key = env.get("S3_SECRET_KEY").unwrap_or_default();
+        let s3_bucket = env.get("S3_BUCKET").unwrap_or_default();
+
+        let pg = BrainAtlasPostgresql::new();
+        let s3 = BrainAtlasS3::new(s3_endpoint, s3_access_key, s3_secret_key, s3_bucket);
         let llm = OpenRouterClient::new();
         let vectordb = BrainAtlasVectorDB::new();
 

--- a/brainatlas-be/crates/infra/src/s3.rs
+++ b/brainatlas-be/crates/infra/src/s3.rs
@@ -1,4 +1,3 @@
-use std::sync::OnceLock;
 use crate::error::InfraError;
 use aws_config::BehaviorVersion;
 use aws_sdk_s3::{
@@ -6,25 +5,33 @@ use aws_sdk_s3::{
     config::{Credentials, Region},
 };
 use services::infra::S3Storage;
+use std::sync::OnceLock;
 use tracing::{error, info};
 
 pub struct BrainAtlasS3 {
     client: OnceLock<Client>,
+    endpoint: String,
+    access_key: String,
+    secret_key: String,
+    bucket: String,
 }
 
 impl BrainAtlasS3 {
-    pub fn new() -> Self {
+    pub fn new(endpoint: String, access_key: String, secret_key: String, bucket: String) -> Self {
         Self {
             client: OnceLock::new(),
+            endpoint,
+            access_key,
+            secret_key,
+            bucket,
         }
     }
 
-    fn get_client(&self, endpoint: &str, access_key: &str, secret_key: &str) -> &Client {
+    fn get_client(&self) -> &Client {
         self.client.get_or_init(|| {
-            // Create new client with custom endpoint and credentials
             let credentials = Credentials::new(
-                access_key,
-                secret_key,
+                &self.access_key,
+                &self.secret_key,
                 None,     // session token
                 None,     // expiration
                 "static", // provider name
@@ -33,13 +40,12 @@ impl BrainAtlasS3 {
             let config = aws_sdk_s3::Config::builder()
                 .behavior_version(BehaviorVersion::latest())
                 .credentials_provider(credentials)
-                .endpoint_url(endpoint)
+                .endpoint_url(&self.endpoint)
                 .region(Region::new("us-east-1")) // Region doesn't matter for self-hosted S3
                 .force_path_style(true) // Required for MinIO and other S3-compatible services
                 .build();
 
-            let client = Client::from_conf(config);
-            client
+            Client::from_conf(config)
         })
     }
 }
@@ -49,35 +55,21 @@ impl S3Storage for BrainAtlasS3 {
     type Error = InfraError;
 
     async fn download(&self, key: &str) -> Result<String, Self::Error> {
-        // Read credentials from environment
-        let endpoint = std::env::var("S3_ENDPOINT").map_err(|_| {
-            InfraError::S3("S3_ENDPOINT not set".to_string())
-        })?;
-        let access_key = std::env::var("S3_ACCESS_KEY").map_err(|_| {
-            InfraError::S3("S3_ACCESS_KEY not set".to_string())
-        })?;
-        let secret_key = std::env::var("S3_SECRET_KEY").map_err(|_| {
-            InfraError::S3("S3_SECRET_KEY not set".to_string())
-        })?;
-        let bucket = std::env::var("S3_BUCKET").map_err(|_| {
-            InfraError::S3("S3_BUCKET not set".to_string())
-        })?;
+        info!("Downloading from S3: s3://{}/{}", self.bucket, key);
 
-        info!("Downloading from S3: s3://{}/{}", bucket, key);
-
-        let client = self.get_client(&endpoint, &access_key, &secret_key);
+        let client = self.get_client();
 
         // Get the object from S3
         let resp = client
             .get_object()
-            .bucket(&bucket)
+            .bucket(&self.bucket)
             .key(key)
             .send()
             .await
             .map_err(|e| {
                 error!(
                     "S3 download failed for s3://{}/{}: {}",
-                    bucket, key, e
+                    self.bucket, key, e
                 );
                 InfraError::S3(e.to_string())
             })?;
@@ -102,7 +94,7 @@ impl S3Storage for BrainAtlasS3 {
         info!(
             "Successfully downloaded {} bytes from s3://{}/{}",
             text.len(),
-            bucket,
+            self.bucket,
             key
         );
 

--- a/brainatlas-be/crates/server/src/main.rs
+++ b/brainatlas-be/crates/server/src/main.rs
@@ -3,7 +3,7 @@ mod server;
 use api::BrainAtlasApi;
 use infra::BrainAtlasInfra;
 use server::BrainAtlasServer;
-use services::BrainAtlasServices;
+use services::{BrainAtlasServices, EnvInfra};
 use std::sync::Arc;
 use tracing::info;
 
@@ -13,17 +13,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    let addr: std::net::SocketAddr = std::env::var("BRAINATLAS_HTTP_ADDR")
+    // Wire infra → services → api → server
+    let infra = Arc::new(BrainAtlasInfra::new());
+
+    let addr: std::net::SocketAddr = infra
+        .get("BRAINATLAS_HTTP_ADDR")
         .unwrap_or_else(|_| "0.0.0.0:8081".to_string())
         .parse()?;
 
-    // Wire infra → services → api → server
-    let infra = Arc::new(BrainAtlasInfra::new());
+    let cors_origin = infra.get("CORS_ORIGIN").ok();
+
     let services = Arc::new(BrainAtlasServices::new(infra));
     let api = Arc::new(BrainAtlasApi::new(services));
     let brain_atlas_server = BrainAtlasServer::new(api);
 
-    let router = brain_atlas_server.into_router();
+    let router = brain_atlas_server.into_router(cors_origin);
 
     info!("brainatlas-be listening on {addr}");
 

--- a/brainatlas-be/crates/server/src/server.rs
+++ b/brainatlas-be/crates/server/src/server.rs
@@ -52,8 +52,8 @@ impl BrainAtlasServer {
         Self { api }
     }
 
-    pub fn into_router(self) -> Router {
-        let cors = cors_layer();
+    pub fn into_router(self, cors_origin: Option<String>) -> Router {
+        let cors = cors_layer(cors_origin);
 
         let api_routes = Router::new()
             .route("/health", get(health_handler))
@@ -75,13 +75,13 @@ impl BrainAtlasServer {
     }
 }
 
-fn cors_layer() -> CorsLayer {
+fn cors_layer(cors_origin: Option<String>) -> CorsLayer {
     let layer = CorsLayer::new()
         .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
         .allow_headers(tower_http::cors::Any);
 
-    match std::env::var("CORS_ORIGIN") {
-        Ok(origins) if origins != "*" => {
+    match cors_origin {
+        Some(origins) if origins != "*" => {
             let allowed: Vec<HeaderValue> = origins
                 .split(',')
                 .filter_map(|o| o.trim().parse::<HeaderValue>().ok())

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -11,9 +11,9 @@ services:
       S3_ACCESS_KEY: ${S3_ACCESS_KEY}
       S3_SECRET_KEY: ${S3_SECRET_KEY}
       S3_BUCKET: ${S3_BUCKET}
-      FETCHER_HTTP_ADDR: ${FETCHER_HTTP_ADDR:-0.0.0.0:8082}
+      FETCHER_HTTP_ADDR: ${FETCHER_HTTP_ADDR:-0.0.0.0:8080}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8082/fetcher-be/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/fetcher-be/health"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -54,16 +54,17 @@ services:
         condition: service_healthy
       brainatlas-be:
         condition: service_healthy
-    env_file:
-      - .env
+    env_file: ".env.orch"
     environment:
-      DATABASE_URL: ${DATABASE_URL}
-      FETCHER_HTTP_ADDR: ${FETCHER_HTTP_ADDR:-http://cortexmap-be:8080}
-      BRAINATLAS_HTTP_ADDR: ${BRAINATLAS_HTTP_ADDR:-http://brainatlas-be:8081}
-      CORS_ORIGIN: ${CORS_ORIGIN:-*}
-      ORCH_HTTP_ADDR: ${ORCH_HTTP_ADDR:-0.0.0.0:8080}
+      # Hardcoded network addresses — always correct on this Docker network.
+      # DATABASE_URL and CORS_ORIGIN intentionally omitted here so they come
+      # exclusively from .env.orch rather than being overridden by the
+      # project-level .env via ${VAR} substitution.
+      FETCHER_HTTP_ADDR: http://cortexmap-be:8080
+      BRAINATLAS_HTTP_ADDR: http://brainatlas-be:8081
+      ORCH_HTTP_ADDR: 0.0.0.0:8082
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/orch/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8082/orch/health"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/fetcher-be/.env.example
+++ b/fetcher-be/.env.example
@@ -11,4 +11,4 @@ S3_SECRET_KEY=minioadmin
 S3_BUCKET=cortexmap
 
 # ── HTTP Server ───────────────────────────────────────────────────────────────
-HTTP_ADDR=0.0.0.0:8080
+FETCHER_HTTP_ADDR=0.0.0.0:8080

--- a/fetcher-be/Dockerfile
+++ b/fetcher-be/Dockerfile
@@ -10,26 +10,26 @@
 #     | docker login --username AWS --password-stdin \
 #         285560394698.dkr.ecr.us-east-1.amazonaws.com
 #
-# 2. Build (non-secret config only — secrets are never baked into the image):
+# 2. Build (no config/secrets baked in — everything is injected at runtime):
 #    NOTE: Must be run from repo root to access both fetcher-be/ and proto/
 #   docker build \
-#     --build-arg DATABASE_URL \
-#     --build-arg S3_ENDPOINT \
-#     --build-arg S3_BUCKET \
 #     -f fetcher-be/Dockerfile \
 #     -t 285560394698.dkr.ecr.us-east-1.amazonaws.com/capstone26t217/fetcher:latest .
 #
 # 3. Push to ECR:
 #   docker push 285560394698.dkr.ecr.us-east-1.amazonaws.com/capstone26t217/fetcher:latest
 #
-# 4. Run (inject secrets at runtime via --env-file or -e):
+# 4. Run (inject all config at runtime via --env-file or -e):
 #   docker run --env-file .env -p 8080:8080 \
 #     285560394698.dkr.ecr.us-east-1.amazonaws.com/capstone26t217/fetcher:latest
 #
 #   Or individually:
 #   docker run \
+#     -e DATABASE_URL=postgres://... \
+#     -e S3_ENDPOINT=http://... \
 #     -e S3_ACCESS_KEY=... \
 #     -e S3_SECRET_KEY=... \
+#     -e S3_BUCKET=cortexmap \
 #     -p 8080:8080 \
 #     285560394698.dkr.ecr.us-east-1.amazonaws.com/capstone26t217/fetcher:latest
 #
@@ -66,20 +66,12 @@ FROM debian:bookworm-slim AS runtime
 RUN apt-get update && apt-get install -y \
     libpq5 \
     ca-certificates \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Non-secret config can be baked in at build time via --build-arg.
-# Secrets (S3_ACCESS_KEY, S3_SECRET_KEY) must never appear in ARG/ENV —
-# supply them exclusively at `docker run` time via --env-file or -e.
-ARG DATABASE_URL
-ARG S3_ENDPOINT
-ARG S3_BUCKET
-ARG HTTP_ADDR=0.0.0.0:8080
-
-ENV DATABASE_URL=${DATABASE_URL}
-ENV S3_ENDPOINT=${S3_ENDPOINT}
-ENV S3_BUCKET=${S3_BUCKET}
-ENV HTTP_ADDR=${HTTP_ADDR}
+# All configuration is injected at container runtime via environment variables.
+# Required: DATABASE_URL, S3_ENDPOINT, S3_ACCESS_KEY, S3_SECRET_KEY, S3_BUCKET
+# Optional: FETCHER_HTTP_ADDR (defaults to 0.0.0.0:8080)
 
 COPY --from=builder /app/target/release/cortexmap-be /usr/local/bin/cortexmap-be
 

--- a/fetcher-be/crates/cortexmap-be/src/main.rs
+++ b/fetcher-be/crates/cortexmap-be/src/main.rs
@@ -10,36 +10,13 @@ async fn main() -> Result<()> {
         .with_max_level(Level::INFO)
         .init();
 
+    let queue_server = QueueServer::from_env().await?;
+
     let addr: SocketAddr = std::env::var("FETCHER_HTTP_ADDR")
         .unwrap_or_else(|_| "0.0.0.0:8080".to_string())
         .parse()?;
 
-    let database_url = std::env::var("DATABASE_URL")
-        .expect("DATABASE_URL must be set");
-
-    let s3_endpoint = std::env::var("S3_ENDPOINT")
-        .expect("S3_ENDPOINT must be set");
-
-    let s3_access_key = std::env::var("S3_ACCESS_KEY")
-        .expect("S3_ACCESS_KEY must be set");
-
-    let s3_secret_key = std::env::var("S3_SECRET_KEY")
-        .expect("S3_SECRET_KEY must be set");
-
-    let s3_bucket = std::env::var("S3_BUCKET")
-        .expect("S3_BUCKET must be set");
-
     info!("Starting CortexMap HTTP server on {}", addr);
-    info!("Database: {}", database_url.split('@').last().unwrap_or("unknown"));
-    info!("S3 Bucket: {}", s3_bucket);
-
-    let queue_server = QueueServer::new(
-        database_url,
-        s3_endpoint,
-        s3_access_key,
-        s3_secret_key,
-        s3_bucket,
-    ).await?;
 
     let router = queue_server.into_router();
 

--- a/fetcher-be/crates/cortexmap-be/src/server.rs
+++ b/fetcher-be/crates/cortexmap-be/src/server.rs
@@ -30,21 +30,15 @@ pub struct QueueServer {
 }
 
 impl QueueServer {
-    pub async fn new(
-        database_url: String,
-        s3_endpoint: String,
-        s3_access_key: String,
-        s3_secret_key: String,
-        s3_bucket: String,
-    ) -> Result<Self, anyhow::Error> {
-        let infra_ctx = StdInfraContext {
-            database_url: database_url.clone(),
-            endpoint: s3_endpoint.clone(),
-            access_key: s3_access_key.clone(),
-            secret_key: s3_secret_key.clone(),
-            bucket: s3_bucket.clone(),
-        };
+    /// Create from runtime environment variables (collected once, reused).
+    pub async fn from_env() -> Result<Self, anyhow::Error> {
+        let infra_ctx = StdInfraContext::from_env()?;
+        Self::new(infra_ctx).await
+    }
 
+    pub async fn new(
+        infra_ctx: StdInfraContext,
+    ) -> Result<Self, anyhow::Error> {
         let ctx = infra_ctx.get()?;
 
         let blueprint_template = Blueprint {
@@ -59,16 +53,23 @@ impl QueueServer {
             },
             connections: Connections {
                 db: Database::Postgresql(Postgresql {
-                    url: database_url,
+                    url: infra_ctx.database_url,
                 }),
                 s3_info: S3Info {
-                    endpoint: s3_endpoint,
-                    access_key: s3_access_key,
-                    secret_key: s3_secret_key,
-                    bucket: s3_bucket,
+                    endpoint: infra_ctx.endpoint,
+                    access_key: infra_ctx.access_key,
+                    secret_key: infra_ctx.secret_key,
+                    bucket: infra_ctx.bucket,
                 },
             },
         };
+
+        info!(
+            "Database: {}",
+            blueprint_template.connections.db_url()
+                .split('@').last().unwrap_or("unknown")
+        );
+        info!("S3 Bucket: {}", blueprint_template.connections.s3_info.bucket);
 
         let worker_manager = Arc::new(RwLock::new(WorkerManager::new()));
 

--- a/fetcher-be/crates/cortexmap-core/src/blueprint/connections/cm_connections.rs
+++ b/fetcher-be/crates/cortexmap-core/src/blueprint/connections/cm_connections.rs
@@ -4,6 +4,14 @@ pub struct Connections {
     pub s3_info: S3Info,
 }
 
+impl Connections {
+    pub fn db_url(&self) -> &str {
+        match &self.db {
+            Database::Postgresql(pg) => &pg.url,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Database {
     Postgresql(Postgresql),

--- a/fetcher-be/crates/cortexmap-infra/src/error.rs
+++ b/fetcher-be/crates/cortexmap-infra/src/error.rs
@@ -26,4 +26,7 @@ pub enum InfraError {
 
     #[error("S3 error: {0}")]
     S3Error(String),
+
+    #[error("env var not found: {0}")]
+    EnvVarNotFound(String),
 }

--- a/fetcher-be/crates/cortexmap-infra/src/infra.rs
+++ b/fetcher-be/crates/cortexmap-infra/src/infra.rs
@@ -6,6 +6,11 @@ use futures::Stream;
 use reqwest::Response;
 use std::pin::Pin;
 
+/// Environment variable access — collect vars once at startup and reuse.
+pub trait EnvInfra: Send + Sync {
+    fn get_env_var(&self, key: &str) -> Result<String, InfraError>;
+}
+
 pub enum ContentType {
     Text,
     Pdf,

--- a/fetcher-be/crates/std-infra/src/env.rs
+++ b/fetcher-be/crates/std-infra/src/env.rs
@@ -1,0 +1,23 @@
+use cortexmap_infra::{EnvInfra, InfraError};
+use std::collections::HashMap;
+
+pub struct FetcherEnvInfra {
+    vars: HashMap<String, String>,
+}
+
+impl FetcherEnvInfra {
+    pub fn new() -> Self {
+        Self {
+            vars: std::env::vars().collect(),
+        }
+    }
+}
+
+impl EnvInfra for FetcherEnvInfra {
+    fn get_env_var(&self, key: &str) -> Result<String, InfraError> {
+        self.vars
+            .get(key)
+            .cloned()
+            .ok_or(InfraError::EnvVarNotFound(key.to_string()))
+    }
+}

--- a/fetcher-be/crates/std-infra/src/infra.rs
+++ b/fetcher-be/crates/std-infra/src/infra.rs
@@ -1,11 +1,12 @@
 use crate::StdDatabaseInfra;
 use crate::database::DbPool;
+use crate::env::FetcherEnvInfra;
 use crate::http::StdHttpInfra;
 use crate::s3::StdS3Infra;
 use crate::task_queue::StdTaskQueue;
 use bytes::Bytes;
 use cortexmap_infra::{
-    ComponentType, ContentType, DatabaseInfra, FetchTask, FetchTaskComponent, HttpInfra,
+    ComponentType, ContentType, DatabaseInfra, EnvInfra, FetchTask, FetchTaskComponent, HttpInfra,
     InfraError, NewFetchTaskLog, NewPaper, Paper, S3Infra,
     TaskQueueInfra, TaskStats, TaskStatus,
 };
@@ -14,6 +15,7 @@ use reqwest::Response;
 use std::pin::Pin;
 
 pub struct StdInfra {
+    env_infra: FetcherEnvInfra,
     http_infra: StdHttpInfra,
     db_infra: StdDatabaseInfra,
     s3_infra: StdS3Infra,
@@ -28,6 +30,7 @@ impl StdInfra {
         secret_key: &str,
         bucket: &str,
     ) -> Result<Self, InfraError> {
+        let env_infra = FetcherEnvInfra::new();
         let http_infra = StdHttpInfra::new();
         let db_infra = StdDatabaseInfra::new(database_url)?;
         let s3_infra = StdS3Infra::new(endpoint, access_key, secret_key, bucket);
@@ -36,6 +39,7 @@ impl StdInfra {
         let task_queue = StdTaskQueue::new(db_infra.pool.clone());
         
         Ok(Self {
+            env_infra,
             http_infra,
             db_infra,
             s3_infra,
@@ -46,6 +50,12 @@ impl StdInfra {
     /// Get the database connection pool for direct queries
     pub fn db_pool(&self) -> &DbPool {
         &self.db_infra.pool
+    }
+}
+
+impl EnvInfra for StdInfra {
+    fn get_env_var(&self, key: &str) -> Result<String, InfraError> {
+        self.env_infra.get_env_var(key)
     }
 }
 

--- a/fetcher-be/crates/std-infra/src/lib.rs
+++ b/fetcher-be/crates/std-infra/src/lib.rs
@@ -1,13 +1,15 @@
 mod database;
+mod env;
 mod http;
 mod infra;
 mod s3;
 mod task_queue;
 
 pub use database::*;
+pub use env::*;
 pub use infra::StdInfra; // Make StdInfra public for testing
 
-use cortexmap_infra::{InfraContext, InfraError};
+use cortexmap_infra::{EnvInfra, InfraContext, InfraError};
 use std::sync::Arc;
 
 #[derive(derive_builder::Builder)]
@@ -20,9 +22,18 @@ pub struct StdInfraContext {
 }
 
 impl StdInfraContext {
-    // Note: Creates a new InfraContext on each call.
-    // Currently simple but could be optimized to use a singleton pattern
-    // to ensure only one instance is created across the application.
+    /// Create from runtime environment variables (collected once, reused).
+    pub fn from_env() -> Result<Self, InfraError> {
+        let env = FetcherEnvInfra::new();
+        Ok(Self {
+            database_url: env.get_env_var("DATABASE_URL")?,
+            endpoint: env.get_env_var("S3_ENDPOINT")?,
+            access_key: env.get_env_var("S3_ACCESS_KEY")?,
+            secret_key: env.get_env_var("S3_SECRET_KEY")?,
+            bucket: env.get_env_var("S3_BUCKET")?,
+        })
+    }
+
     pub fn get(&self) -> Result<InfraContext<StdInfra>, InfraError> {
         Ok(InfraContext {
             infra: Arc::new(StdInfra::new(

--- a/orch/Dockerfile
+++ b/orch/Dockerfile
@@ -69,6 +69,7 @@ FROM debian:bookworm-slim AS runtime
 RUN apt-get update && apt-get install -y \
     libpq5 \
     ca-certificates \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # All runtime vars (DATABASE_URL, FETCHER_HTTP_ADDR, BRAINATLAS_HTTP_ADDR) are

--- a/orch/crates/infra/src/http.rs
+++ b/orch/crates/infra/src/http.rs
@@ -1,6 +1,6 @@
 use crate::InfraError;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use services::HttpClient as HttpClientTrait;
 
 pub struct OrchHttpClient {
@@ -18,13 +18,17 @@ impl OrchHttpClient {
 #[async_trait::async_trait]
 impl HttpClientTrait for OrchHttpClient {
     type Error = InfraError;
-    
+
     async fn get<T: DeserializeOwned + Send>(&self, url: &str) -> Result<T, Self::Error> {
+        tracing::debug!(url = url, "HTTP GET");
         let response = self.client.get(url).send().await?;
-        
+
         let status = response.status();
         if !status.is_success() {
-            let error_body = response.text().await.unwrap_or_else(|_| "(could not read response)".to_string());
+            let error_body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "(could not read response)".to_string());
             tracing::error!(
                 url = url,
                 status = %status,
@@ -36,20 +40,24 @@ impl HttpClientTrait for OrchHttpClient {
                 body: error_body,
             });
         }
-        
+
         Ok(response.json().await?)
     }
-    
+
     async fn post<Req: Serialize + Send + Sync, Res: DeserializeOwned + Send + Sync>(
         &self,
         url: &str,
         body: &Req,
     ) -> Result<Res, Self::Error> {
+        tracing::debug!(url = url, "HTTP POST");
         let response = self.client.post(url).json(body).send().await?;
-        
+
         let status = response.status();
         if !status.is_success() {
-            let error_body = response.text().await.unwrap_or_else(|_| "(could not read response)".to_string());
+            let error_body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "(could not read response)".to_string());
             tracing::error!(
                 url = url,
                 status = %status,
@@ -61,14 +69,15 @@ impl HttpClientTrait for OrchHttpClient {
                 body: error_body,
             });
         }
-        
+
         Ok(response.json().await?)
     }
-    
+
     async fn check_health(&self, base_url: &str, service_name: &str) -> Result<(), Self::Error> {
         let url = format!("{}/health", base_url);
-        
-        let response = self.client
+
+        let response = self
+            .client
             .get(&url)
             .timeout(std::time::Duration::from_secs(5))
             .send()
@@ -82,7 +91,7 @@ impl HttpClientTrait for OrchHttpClient {
                 );
                 InfraError::from(e)
             })?;
-        
+
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
@@ -95,13 +104,13 @@ impl HttpClientTrait for OrchHttpClient {
             );
             return Err(InfraError::NotFound);
         }
-        
+
         tracing::info!(
             service = service_name,
             base_url = base_url,
             "Health check passed"
         );
-        
+
         Ok(())
     }
 }

--- a/orch/crates/server/src/main.rs
+++ b/orch/crates/server/src/main.rs
@@ -9,7 +9,7 @@ use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    dotenvy::dotenv().ok();
+    // dotenvy::dotenv().ok();
     
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())

--- a/orch/crates/services/src/services.rs
+++ b/orch/crates/services/src/services.rs
@@ -146,12 +146,15 @@ where
     async fn get_all_regions(&self) -> Result<Vec<domain::Region>, Self::Error> {
         self.region_management.get_all_regions().await
     }
-    
+
     async fn delete_queries(&self, region_id: Uuid) -> Result<(), Self::Error> {
         self.region_management.delete_queries(region_id).await
     }
 
-    async fn get_chunk_source(&self, chunk_id: Uuid) -> Result<domain::ChunkSourceResponse, Self::Error> {
+    async fn get_chunk_source(
+        &self,
+        chunk_id: Uuid,
+    ) -> Result<domain::ChunkSourceResponse, Self::Error> {
         self.region_management.get_chunk_source(chunk_id).await
     }
 }
@@ -215,22 +218,25 @@ where
             .await
     }
 
-    async fn update_batch_expected_count(&self, batch_id: Uuid, count: i32) -> Result<(), Self::Error> {
+    async fn update_batch_expected_count(
+        &self,
+        batch_id: Uuid,
+        count: i32,
+    ) -> Result<(), Self::Error> {
         self.batch_orchestration
             .update_batch_expected_count(batch_id, count)
             .await
     }
 
-    async fn get_batch_by_id(&self, batch_id: Uuid) -> Result<Option<domain::ProcessingBatch>, Self::Error> {
-        self.batch_orchestration
-            .get_batch_by_id(batch_id)
-            .await
+    async fn get_batch_by_id(
+        &self,
+        batch_id: Uuid,
+    ) -> Result<Option<domain::ProcessingBatch>, Self::Error> {
+        self.batch_orchestration.get_batch_by_id(batch_id).await
     }
 
     async fn ensure_workers_allocated(&self) -> Result<(), Self::Error> {
-        self.batch_orchestration
-            .ensure_workers_allocated()
-            .await
+        self.batch_orchestration.ensure_workers_allocated().await
     }
 }
 
@@ -259,7 +265,11 @@ where
             }
         })?;
 
+        tracing::debug!("Fetcher HTTP address: {}", fetcher_addr);
+
         let fetcher_url = format!("{}/fetcher-be", normalize_url(&fetcher_addr));
+
+        tracing::debug!("Fetcher URL: {}", fetcher_url);
 
         self.infra
             .check_health(&fetcher_url, "fetcher")


### PR DESCRIPTION
## Problem

Env vars were being **baked into Docker images at build time** via `ARG`/`ENV` blocks, and read ad-hoc via scattered `std::env::var()` calls in entry points. This meant:
- A rebuild was required to change `DATABASE_URL`, `S3_ENDPOINT`, `S3_BUCKET`, `CORS_ORIGIN`, etc.
- The same image couldn't be reused across environments (dev/staging/prod)
- Config was duplicated in both the image layer and docker-compose

## Solution

All env vars are now read **once at container startup** from the process environment via a `HashMap` snapshot (`EnvInfra` pattern), then reused throughout the service lifetime. Docker images are now fully config-free -- all values come from `docker-compose environment:` or `--env-file` at runtime.

## Changes

### fetcher-be
- **`std-infra/src/env.rs`** (new): `FetcherEnvInfra` -- snapshots all env vars into a `HashMap` at startup
- **`cortexmap-infra/src/infra.rs`**: add `EnvInfra` trait with `get_env_var()`
- **`cortexmap-infra/src/error.rs`**: add `EnvVarNotFound` variant
- **`std-infra/src/lib.rs`**: add `StdInfraContext::from_env()` constructor
- **`std-infra/src/infra.rs`**: `StdInfra` implements `EnvInfra` by delegation
- **`cortexmap-be/src/main.rs`**: replace 6 scattered `std::env::var()` calls with `QueueServer::from_env()`
- **`cortexmap-be/src/server.rs`**: `QueueServer::new()` takes `StdInfraContext` instead of 5 raw strings; add `from_env()`
- **`Dockerfile`**: remove `ARG`/`ENV` block baking `DATABASE_URL`, `S3_*`, `HTTP_ADDR`; add `curl`; no `--build-arg` needed
- **`.env.example`**: fix `HTTP_ADDR` → `FETCHER_HTTP_ADDR` naming mismatch

### brainatlas-be
- **`infra/src/infra.rs`**: `BrainAtlasInfra::new()` reads S3 config from `BrainAtlasEnvInfra` and passes to `BrainAtlasS3::new()`
- **`infra/src/s3.rs`**: `BrainAtlasS3::new()` accepts config as constructor params instead of reading `std::env::var`
- **`server/src/main.rs`**: infra created first; `BRAINATLAS_HTTP_ADDR` and `CORS_ORIGIN` read through `infra.get()`; `cors_origin` passed to `into_router()`
- **`server/src/server.rs`**: `into_router()` and `cors_layer()` accept `cors_origin: Option<String>` param
- **`Dockerfile`**: remove `ARG CORS_ORIGIN`, `ARG HTTP_ADDR`, `ENV` baking; add `curl`; no `--build-arg` needed

## Result

```bash
# Before (secrets required at build time):
docker build --build-arg DATABASE_URL --build-arg S3_ENDPOINT --build-arg CORS_ORIGIN ...

# After (one image, all environments):
docker build -f fetcher-be/Dockerfile -t .../fetcher:latest .
docker build -f brainatlas-be/Dockerfile -t .../brainatlas-be:latest .
```

Only **one** `std::env::var` call remains per service -- in `env.rs` where the HashMap snapshot is collected. All other reads go through `EnvInfra::get()`.