### PR TITLE
feature(evals): add batch eval API and gated rubric metrics

### DIFF
--- a/brainatlas-be/crates/app/prompts/judge_rubric_system.md
+++ b/brainatlas-be/crates/app/prompts/judge_rubric_system.md
@@ -8,6 +8,8 @@ Score the summary against the following five criteria, each on an integer scale 
 4. **clinical_utility** — Would a clinician or researcher find this summary actionable for understanding disorders, lesion symptoms, or treatment targets? (1 = useless clinically, 5 = directly useful.)
 5. **terminology** — Is the scientific vocabulary correct, current, and used consistently? (1 = many errors or anachronisms, 5 = expert-level precision.)
 
+**Factual-accuracy guardrail.** If the summary places {{REGION_NAME}} in the wrong organ system or anatomical division (e.g., describes a cortical region as midbrain, a telencephalic nucleus as brainstem, or a cerebellar structure as cortical), or attributes functions/connections that clearly contradict established neuroanatomy (e.g., claims an olfactory area drives ocular orienting reflexes), score `relevance`, `specificity`, and `terminology` each no higher than `2` — regardless of how well-written the prose is. Confident-sounding fiction must not receive a high rubric score.
+
 For each criterion, also provide a one-sentence rationale (≤ 25 words) justifying the score.
 
 **Output format — return ONLY a single JSON object** matching this schema (no commentary, no markdown fence):

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -105,6 +105,7 @@ services:
       # proxied through brainatlas-be.
       DATABASE_URL: ${DATABASE_URL}
       BRAINATLAS_BASE_URL: ${EVALS_BRAINATLAS_BASE_URL:-http://brainatlas-be:8081}
+      EVAL_VERSION: v0.4.0
       EVALS_HTTP_ADDR: 0.0.0.0:8083
       CORS_ORIGIN: ${CORS_ORIGIN:-*}
     ports:

--- a/evals-be/Cargo.lock
+++ b/evals-be/Cargo.lock
@@ -518,6 +518,7 @@ dependencies = [
  "rpc-types",
  "serde",
  "serde_json",
+ "strsim",
  "thiserror",
  "tokio",
  "tracing",

--- a/evals-be/Cargo.toml
+++ b/evals-be/Cargo.toml
@@ -33,3 +33,4 @@ futures = "0.3"
 sha2 = "0.10"
 pgvector = { version = "0.4", features = ["diesel"] }
 regex = "1"
+strsim = "0.11"

--- a/evals-be/Dockerfile
+++ b/evals-be/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Run-time env vars:
 #   DATABASE_URL=postgres://...
-#   EVAL_VERSION=v0.3.0        (optional; defaults from domain::ConfigKey)
+#   EVAL_VERSION=v0.4.0        (optional; defaults from domain::ConfigKey)
 #   EVAL_JUDGE_CHAT_MODEL=...  (optional)
 #   EVAL_RUBRIC_CHAT_MODEL=... (optional)
 #   EVAL_EMBEDDING_MODEL=...   (optional)

--- a/evals-be/crates/api/src/api.rs
+++ b/evals-be/crates/api/src/api.rs
@@ -37,10 +37,7 @@ pub trait EvalsApi: Send + Sync {
         eval_version: Option<String>,
         limit: i64,
     ) -> Result<UnscoredResponse, Self::Error>;
-    async fn batch_eval(
-        &self,
-        req: BatchEvalRequest,
-    ) -> Result<BatchEvalResponse, Self::Error>;
+    async fn batch_eval(&self, req: BatchEvalRequest) -> Result<BatchEvalResponse, Self::Error>;
 }
 
 pub struct Evals<DB, EN, E>
@@ -123,10 +120,7 @@ where
             .map_err(ApiError::AppError)
     }
 
-    async fn batch_eval(
-        &self,
-        req: BatchEvalRequest,
-    ) -> Result<BatchEvalResponse, Self::Error> {
+    async fn batch_eval(&self, req: BatchEvalRequest) -> Result<BatchEvalResponse, Self::Error> {
         self.app
             .clone()
             .batch_eval(req)

--- a/evals-be/crates/api/src/api.rs
+++ b/evals-be/crates/api/src/api.rs
@@ -4,8 +4,8 @@
 use crate::error::ApiError;
 use app::{AppError, EvalsApp};
 use rpc_types::{
-    EvalSummaryResponse, InitScoreRequest, InitScoreResponse, ScoresForSummaryResponse,
-    StepRequest, StepResponse, UnscoredResponse, WorstOffendersResponse,
+    BatchEvalRequest, BatchEvalResponse, EvalSummaryResponse, InitScoreRequest, InitScoreResponse,
+    ScoresForSummaryResponse, StepRequest, StepResponse, UnscoredResponse, WorstOffendersResponse,
 };
 use services::{EnvInfra, EvalsDatabase};
 use std::error::Error;
@@ -37,6 +37,10 @@ pub trait EvalsApi: Send + Sync {
         eval_version: Option<String>,
         limit: i64,
     ) -> Result<UnscoredResponse, Self::Error>;
+    async fn batch_eval(
+        &self,
+        req: BatchEvalRequest,
+    ) -> Result<BatchEvalResponse, Self::Error>;
 }
 
 pub struct Evals<DB, EN, E>
@@ -62,8 +66,8 @@ where
 #[async_trait::async_trait]
 impl<DB, EN, E> EvalsApi for Evals<DB, EN, E>
 where
-    DB: EvalsDatabase<Error = E>,
-    EN: EnvInfra<Error = E>,
+    DB: EvalsDatabase<Error = E> + 'static,
+    EN: EnvInfra<Error = E> + 'static,
     E: Error + Send + Sync + 'static,
 {
     type Error = ApiError<AppError<E>>;
@@ -115,6 +119,17 @@ where
     ) -> Result<UnscoredResponse, Self::Error> {
         self.app
             .list_unscored_summary_ids(eval_version, limit)
+            .await
+            .map_err(ApiError::AppError)
+    }
+
+    async fn batch_eval(
+        &self,
+        req: BatchEvalRequest,
+    ) -> Result<BatchEvalResponse, Self::Error> {
+        self.app
+            .clone()
+            .batch_eval(req)
             .await
             .map_err(ApiError::AppError)
     }

--- a/evals-be/crates/api/src/router.rs
+++ b/evals-be/crates/api/src/router.rs
@@ -14,7 +14,7 @@ use axum::http::{HeaderValue, Method, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use rpc_types::{InitScoreRequest, StepRequest};
+use rpc_types::{BatchEvalRequest, InitScoreRequest, StepRequest};
 use serde::Deserialize;
 use std::error::Error;
 use std::sync::Arc;
@@ -38,6 +38,7 @@ where
     let routes = Router::new()
         .route("/health", get(health))
         .route("/api/evals/score/init", post(init_score::<A, E>))
+        .route("/api/evals/batch", post(batch_eval::<A, E>))
         .route("/api/evals/score/step", post(step_score::<A, E>))
         .route(
             "/api/evals/scores/{summary_id}",
@@ -140,6 +141,18 @@ where
 {
     let resp = state.api.init_score(req).await?;
     Ok(Json(resp).into_response())
+}
+
+async fn batch_eval<A, E>(
+    State(state): State<AppState<A>>,
+    Json(req): Json<BatchEvalRequest>,
+) -> Result<Response, ServerError<E>>
+where
+    A: EvalsApi<Error = ApiError<AppError<E>>> + 'static,
+    E: Error + Send + Sync + 'static,
+{
+    let resp = state.api.batch_eval(req).await?;
+    Ok((StatusCode::ACCEPTED, Json(resp)).into_response())
 }
 
 async fn step_score<A, E>(

--- a/evals-be/crates/app/src/app.rs
+++ b/evals-be/crates/app/src/app.rs
@@ -519,8 +519,12 @@ where
         })
     }
 
-    /// Active summary IDs that have no `complete` `eval_runs` row for the
-    /// given `eval_version`. Used by the orch eval-orchestrator to find work.
+    /// Summary IDs explicitly queued for evaluation for the given
+    /// `eval_version`. Used by the orch eval-orchestrator to find work.
+    ///
+    /// Only summaries with an existing `eval_runs` row are returned:
+    /// queued rows are runnable immediately, and stale running rows are
+    /// returned for recovery after worker interruption.
     pub async fn list_unscored_summary_ids(
         &self,
         eval_version: Option<String>,
@@ -540,16 +544,17 @@ where
         })
     }
 
-    /// Trigger eval runs for a list of summaries in the background.
+    /// Queue eval runs for a list of summaries.
     ///
-    /// Each `summary_id` gets its own independent `tokio::spawn`-ed task that
-    /// calls [`Self::init_score`] — identical to calling `POST /score/init`
-    /// per ID. This method returns immediately (HTTP 202) before any task
-    /// completes. The returned `batch_eval_id` is an ephemeral correlation
-    /// UUID useful for log tracing; it is not persisted.
+    /// Each `summary_id` is marked `queued` in `eval_runs` for the effective
+    /// eval version, and orch later picks it up via `/api/evals/unscored` to
+    /// drive the full `init -> step -> ... -> done` loop. This method returns
+    /// immediately (HTTP 202) after the queue rows are written. The returned
+    /// `batch_eval_id` is an ephemeral correlation UUID useful for log tracing;
+    /// it is not persisted.
     ///
-    /// Repeated calls with overlapping IDs are intentional and produce
-    /// independent tasks — no deduplication occurs.
+    /// Repeated calls are idempotent at the `(summary_id, eval_version)`
+    /// level: the existing `eval_runs` row is refreshed back to `queued`.
     ///
     /// # Errors
     /// Returns `AppError::InvalidArg` if `summary_ids` is empty.
@@ -568,33 +573,27 @@ where
         }
 
         let batch_eval_id = Uuid::new_v4();
-        let accepted = req.summary_ids.clone();
+        let eval_version = req
+            .eval_version
+            .clone()
+            .unwrap_or_else(|| self.config.eval_version.clone());
 
-        for summary_id in req.summary_ids {
-            let app = self.clone();
-            let eval_version = req.eval_version.clone();
-            let bid = batch_eval_id;
-            tokio::spawn(async move {
-                let result = app
-                    .init_score(InitScoreRequest {
-                        summary_id,
-                        eval_version,
-                    })
-                    .await;
-                if let Err(e) = result {
-                    tracing::warn!(
-                        batch_eval_id = %bid,
-                        %summary_id,
-                        error = %e,
-                        "batch_eval: init_score task failed",
-                    );
-                }
-            });
+        for &summary_id in &req.summary_ids {
+            self.db
+                .upsert_run(
+                    &self.config.database_url,
+                    summary_id,
+                    &eval_version,
+                    EvalRunStatus::Queued,
+                    None,
+                )
+                .await
+                .map_err(ServiceError::InfraError)?;
         }
 
         Ok(BatchEvalResponse {
             batch_eval_id,
-            accepted,
+            accepted: req.summary_ids,
         })
     }
 }
@@ -635,6 +634,7 @@ mod tests {
     use async_trait::async_trait;
     use chrono::NaiveDateTime;
     use domain::{EvalRun, EvalRunStatus, EvalScore, NewEvalScore};
+    use rpc_types::BatchEvalRequest;
     use services::{
         ChunkRow, EnvInfra, EvalAggregate, EvalsDatabase, LoadedRunState, MetricStatsRaw,
         RetrievedChunk, SummaryRow, WorstOffenderRow,
@@ -835,6 +835,126 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct QueueingDb {
+        queued: Mutex<Vec<(Uuid, String, EvalRunStatus)>>,
+    }
+
+    #[async_trait]
+    impl EvalsDatabase for QueueingDb {
+        type Error = MockErr;
+
+        async fn lookup_score_by_hash(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> Result<Option<EvalScore>, MockErr> {
+            unimplemented!("queueing tests never hit lookup_score_by_hash")
+        }
+        async fn insert_score(&self, _: &str, _: NewEvalScore) -> Result<EvalScore, MockErr> {
+            unimplemented!("queueing tests never hit insert_score")
+        }
+        async fn get_summary(&self, _: &str, _: Uuid) -> Result<Option<SummaryRow>, MockErr> {
+            unimplemented!("queueing tests never hit get_summary")
+        }
+        async fn get_scores_for_summary(&self, _: &str, _: Uuid) -> Result<Vec<EvalScore>, MockErr> {
+            unimplemented!("queueing tests never hit get_scores_for_summary")
+        }
+        async fn get_eval_aggregate(&self, _: &str, _: &str) -> Result<EvalAggregate, MockErr> {
+            unimplemented!("queueing tests never hit get_eval_aggregate")
+        }
+        async fn get_worst_offenders(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: i64,
+        ) -> Result<Vec<WorstOffenderRow>, MockErr> {
+            unimplemented!("queueing tests never hit get_worst_offenders")
+        }
+        async fn upsert_run(
+            &self,
+            _: &str,
+            summary_id: Uuid,
+            eval_version: &str,
+            status: EvalRunStatus,
+            _: Option<String>,
+        ) -> Result<EvalRun, MockErr> {
+            self.queued
+                .lock()
+                .unwrap()
+                .push((summary_id, eval_version.to_string(), status));
+            Ok(EvalRun {
+                id: Uuid::new_v4(),
+                summary_id,
+                eval_version: eval_version.to_string(),
+                status,
+                error_message: None,
+                started_at: None,
+                completed_at: None,
+                created_at: NaiveDateTime::default(),
+            })
+        }
+        async fn list_unscored_summary_ids(
+            &self,
+            _: &str,
+            _: &str,
+            _: i64,
+        ) -> Result<Vec<Uuid>, MockErr> {
+            unimplemented!("queueing tests never hit list_unscored_summary_ids")
+        }
+        async fn retrieve_chunks_for_summary(
+            &self,
+            _: &str,
+            _: Uuid,
+            _: &[f32],
+            _: i64,
+            _: f32,
+        ) -> Result<Vec<RetrievedChunk>, MockErr> {
+            unimplemented!("queueing tests never hit retrieve_chunks_for_summary")
+        }
+        async fn load_chunks_by_ids(&self, _: &str, _: &[Uuid]) -> Result<Vec<ChunkRow>, MockErr> {
+            unimplemented!("queueing tests never hit load_chunks_by_ids")
+        }
+        async fn insert_run_state(
+            &self,
+            _: &str,
+            _: Uuid,
+            _: &str,
+            _: &serde_json::Value,
+            _: Option<Uuid>,
+            _: Option<&str>,
+        ) -> Result<Uuid, MockErr> {
+            unimplemented!("queueing tests never hit insert_run_state")
+        }
+        async fn load_run_state(&self, _: &str, _: Uuid) -> Result<Option<LoadedRunState>, MockErr> {
+            unimplemented!("queueing tests never hit load_run_state")
+        }
+        async fn save_run_state(
+            &self,
+            _: &str,
+            _: Uuid,
+            _: &serde_json::Value,
+            _: Option<Uuid>,
+            _: Option<&str>,
+        ) -> Result<(), MockErr> {
+            unimplemented!("queueing tests never hit save_run_state")
+        }
+        async fn delete_run_state(&self, _: &str, _: Uuid) -> Result<(), MockErr> {
+            unimplemented!("queueing tests never hit delete_run_state")
+        }
+        async fn delete_run_states_for_summary(
+            &self,
+            _: &str,
+            _: Uuid,
+            _: &str,
+        ) -> Result<(), MockErr> {
+            unimplemented!("queueing tests never hit delete_run_states_for_summary")
+        }
+    }
+
     fn min_config() -> EvalRuntimeConfig {
         EvalRuntimeConfig {
             database_url: "memory://".to_string(),
@@ -850,6 +970,14 @@ mod tests {
     }
 
     fn make_app(db: Arc<ReadOnlyDb>) -> EvalsApp<ReadOnlyDb, StubEnv, MockErr> {
+        EvalsApp {
+            db,
+            env: Arc::new(StubEnv::new()),
+            config: min_config(),
+        }
+    }
+
+    fn make_queueing_app(db: Arc<QueueingDb>) -> EvalsApp<QueueingDb, StubEnv, MockErr> {
         EvalsApp {
             db,
             env: Arc::new(StubEnv::new()),
@@ -1080,10 +1208,11 @@ mod tests {
         assert_eq!(resp.entries[0].region_name.as_deref(), Some("Hippocampus"));
     }
 
-    /// `list_unscored_summary_ids` surfaces the raw Uuid list and echoes
-    /// back the effective version (the override when set).
+    /// `list_unscored_summary_ids` surfaces only explicitly queued or
+    /// stale-in-flight summary IDs and echoes back the effective version
+    /// (the override when set).
     #[tokio::test]
-    async fn list_unscored_summary_ids_echoes_version_and_limit() {
+    async fn list_unscored_summary_ids_echoes_version_limit_and_preserves_queue_order() {
         let db = Arc::new(ReadOnlyDb::default());
         let a = Uuid::new_v4();
         let b = Uuid::new_v4();
@@ -1135,6 +1264,51 @@ mod tests {
             }
             other => panic!("expected InvalidArg, got {other:?}"),
         }
+    }
+
+    /// `batch_eval` rejects an empty request body rather than silently doing
+    /// nothing, which keeps the HTTP 400 contract stable.
+    #[tokio::test]
+    async fn batch_eval_empty_ids_is_invalid_arg() {
+        let db = Arc::new(QueueingDb::default());
+        let app = Arc::new(make_queueing_app(db));
+        let err = app
+            .batch_eval(BatchEvalRequest {
+                summary_ids: vec![],
+                eval_version: None,
+            })
+            .await
+            .expect_err("empty batch must error");
+        match err {
+            AppError::InvalidArg(msg) => assert!(msg.contains("summary_ids must not be empty")),
+            other => panic!("expected InvalidArg, got {other:?}"),
+        }
+    }
+
+    /// `batch_eval` writes one queued run per requested summary using the
+    /// effective eval version that orch later drains via `/unscored`.
+    #[tokio::test]
+    async fn batch_eval_marks_each_summary_as_queued() {
+        let db = Arc::new(QueueingDb::default());
+        let app = Arc::new(make_queueing_app(db.clone()));
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+
+        let resp = app
+            .batch_eval(BatchEvalRequest {
+                summary_ids: vec![a, b],
+                eval_version: Some("v-batch".to_string()),
+            })
+            .await
+            .expect("batch_eval must succeed");
+
+        assert_eq!(resp.accepted, vec![a, b]);
+        assert_ne!(resp.batch_eval_id, Uuid::nil());
+
+        let queued = db.queued.lock().unwrap();
+        assert_eq!(queued.len(), 2);
+        assert_eq!(queued[0], (a, "v-batch".to_string(), EvalRunStatus::Queued));
+        assert_eq!(queued[1], (b, "v-batch".to_string(), EvalRunStatus::Queued));
     }
 
     // ---- Private helpers ----

--- a/evals-be/crates/app/src/app.rs
+++ b/evals-be/crates/app/src/app.rs
@@ -10,9 +10,9 @@ use crate::run_eval::{
 };
 use domain::{EvalRunStatus, compute_hash};
 use rpc_types::{
-    EvalSummaryResponse, InitScoreRequest, InitScoreResponse, LlmEndpoint, MetricResult,
-    MetricStats, NextAction, ScoreEntry, ScoresForSummaryResponse, StepRequest, StepResponse,
-    UnscoredResponse, WorstOffender, WorstOffendersResponse,
+    BatchEvalRequest, BatchEvalResponse, EvalSummaryResponse, InitScoreRequest, InitScoreResponse,
+    LlmEndpoint, MetricResult, MetricStats, NextAction, ScoreEntry, ScoresForSummaryResponse,
+    StepRequest, StepResponse, UnscoredResponse, WorstOffender, WorstOffendersResponse,
 };
 use services::state_machine::{self, RunContext, RunState};
 use services::{EnvInfra, EvalsDatabase, ServiceError};
@@ -537,6 +537,64 @@ where
             eval_version: ver,
             limit,
             summary_ids: ids,
+        })
+    }
+
+    /// Trigger eval runs for a list of summaries in the background.
+    ///
+    /// Each `summary_id` gets its own independent `tokio::spawn`-ed task that
+    /// calls [`Self::init_score`] — identical to calling `POST /score/init`
+    /// per ID. This method returns immediately (HTTP 202) before any task
+    /// completes. The returned `batch_eval_id` is an ephemeral correlation
+    /// UUID useful for log tracing; it is not persisted.
+    ///
+    /// Repeated calls with overlapping IDs are intentional and produce
+    /// independent tasks — no deduplication occurs.
+    ///
+    /// # Errors
+    /// Returns `AppError::InvalidArg` if `summary_ids` is empty.
+    pub async fn batch_eval(
+        self: Arc<Self>,
+        req: BatchEvalRequest,
+    ) -> Result<BatchEvalResponse, AppError<E>>
+    where
+        DB: 'static,
+        EN: 'static,
+    {
+        if req.summary_ids.is_empty() {
+            return Err(AppError::InvalidArg(
+                "summary_ids must not be empty".to_string(),
+            ));
+        }
+
+        let batch_eval_id = Uuid::new_v4();
+        let accepted = req.summary_ids.clone();
+
+        for summary_id in req.summary_ids {
+            let app = self.clone();
+            let eval_version = req.eval_version.clone();
+            let bid = batch_eval_id;
+            tokio::spawn(async move {
+                let result = app
+                    .init_score(InitScoreRequest {
+                        summary_id,
+                        eval_version,
+                    })
+                    .await;
+                if let Err(e) = result {
+                    tracing::warn!(
+                        batch_eval_id = %bid,
+                        %summary_id,
+                        error = %e,
+                        "batch_eval: init_score task failed",
+                    );
+                }
+            });
+        }
+
+        Ok(BatchEvalResponse {
+            batch_eval_id,
+            accepted,
         })
     }
 }

--- a/evals-be/crates/app/src/app.rs
+++ b/evals-be/crates/app/src/app.rs
@@ -859,7 +859,11 @@ mod tests {
         async fn get_summary(&self, _: &str, _: Uuid) -> Result<Option<SummaryRow>, MockErr> {
             unimplemented!("queueing tests never hit get_summary")
         }
-        async fn get_scores_for_summary(&self, _: &str, _: Uuid) -> Result<Vec<EvalScore>, MockErr> {
+        async fn get_scores_for_summary(
+            &self,
+            _: &str,
+            _: Uuid,
+        ) -> Result<Vec<EvalScore>, MockErr> {
             unimplemented!("queueing tests never hit get_scores_for_summary")
         }
         async fn get_eval_aggregate(&self, _: &str, _: &str) -> Result<EvalAggregate, MockErr> {
@@ -929,7 +933,11 @@ mod tests {
         ) -> Result<Uuid, MockErr> {
             unimplemented!("queueing tests never hit insert_run_state")
         }
-        async fn load_run_state(&self, _: &str, _: Uuid) -> Result<Option<LoadedRunState>, MockErr> {
+        async fn load_run_state(
+            &self,
+            _: &str,
+            _: Uuid,
+        ) -> Result<Option<LoadedRunState>, MockErr> {
             unimplemented!("queueing tests never hit load_run_state")
         }
         async fn save_run_state(

--- a/evals-be/crates/app/src/run_eval.rs
+++ b/evals-be/crates/app/src/run_eval.rs
@@ -145,6 +145,11 @@ where
 
 /// Probe the `eval_scores` cache for all 5 rubric metrics. Returns `true` if
 /// all 5 are cached (and pushes them to `out`), `false` otherwise.
+///
+/// Also additively surfaces the 5 `rubric_*_gated` derived metrics when they
+/// exist, so a full cache hit returns them on the `Done` response. Missing
+/// gated rows do NOT gate the state machine — they'll be written by
+/// `advance_rubric` on the next fresh-rubric pass.
 pub async fn probe_rubric_cache<DB, E>(
     db: &DB,
     database_url: &str,
@@ -182,6 +187,32 @@ where
             judge_model: row.judge_model,
         });
     }
+
+    // Additively surface gated rubric rows if present. Missing gated rows do
+    // not cause this probe to report a cache miss: the raw rubric rows are
+    // the authoritative cache-hit signal, and gated rows are cheap to
+    // recompute from `raw × claim_groundedness` on any future run.
+    for m in [
+        EvalMetric::RubricRelevanceGated,
+        EvalMetric::RubricCoherenceGated,
+        EvalMetric::RubricSpecificityGated,
+        EvalMetric::RubricClinicalUtilityGated,
+        EvalMetric::RubricTerminologyGated,
+    ] {
+        let row = db
+            .lookup_score_by_hash(database_url, summary_hash, m.as_str(), eval_version)
+            .await
+            .map_err(ServiceError::InfraError)?;
+        if let Some(r) = row {
+            out.push(MetricResult {
+                metric: r.metric,
+                score: r.score,
+                cached: true,
+                judge_model: r.judge_model,
+            });
+        }
+    }
+
     Ok(true)
 }
 

--- a/evals-be/crates/app/tests/cache_hit.rs
+++ b/evals-be/crates/app/tests/cache_hit.rs
@@ -441,7 +441,7 @@ async fn run_to_done(
 }
 
 #[tokio::test]
-async fn init_and_step_score_produce_14_metrics_first_run_cache_hit_second() {
+async fn init_and_step_score_produce_19_metrics_first_run_cache_hit_second() {
     let summary = fixture_summary();
     let summary_id = summary.id;
 
@@ -453,8 +453,8 @@ async fn init_and_step_score_produce_14_metrics_first_run_cache_hit_second() {
 
     assert_eq!(
         first_metrics.len(),
-        14,
-        "first run must produce 14 metrics (4 structural + 2 groundedness + 5 rubric + 3 deterministic citation), got {}",
+        19,
+        "first run must produce 19 metrics (4 structural + 2 groundedness + 5 rubric + 5 gated rubric + 3 deterministic citation), got {}",
         first_metrics.len()
     );
     assert!(
@@ -477,8 +477,8 @@ async fn init_and_step_score_produce_14_metrics_first_run_cache_hit_second() {
     );
     assert_eq!(
         second_metrics.len(),
-        14,
-        "second run must also produce 14 metrics"
+        19,
+        "second run must also produce 19 metrics"
     );
     assert!(
         second_metrics.iter().all(|m| m.cached),

--- a/evals-be/crates/domain/src/config.rs
+++ b/evals-be/crates/domain/src/config.rs
@@ -31,7 +31,7 @@ pub enum ConfigKey {
 impl ConfigKey {
     pub fn default_value(self) -> &'static str {
         match self {
-            ConfigKey::EvalVersion => "v0.3.0",
+            ConfigKey::EvalVersion => "v0.4.0",
             ConfigKey::EvalConcurrency => "5",
             ConfigKey::EvalJudgeChatModel => "openai/gpt-4o-mini",
             ConfigKey::EvalRubricChatModel => "openai/gpt-4o",

--- a/evals-be/crates/domain/src/evals.rs
+++ b/evals-be/crates/domain/src/evals.rs
@@ -85,6 +85,20 @@ pub enum EvalMetric {
     RubricClinicalUtility,
     RubricTerminology,
 
+    // ---- Rubric gated by groundedness (derived, no LLM) ----
+    //
+    // Each `rubric_*_gated = rubric_* * claim_groundedness`.
+    // The rubric judge sees no source chunks, so it grades prose style
+    // conditional on the prose being trusted. Multiplying by groundedness
+    // converts "writing quality" into "writing quality weighted by whether
+    // the facts are grounded in evidence", preventing confidently-wrong
+    // summaries from hiding behind a near-1.0 rubric score.
+    RubricRelevanceGated,
+    RubricCoherenceGated,
+    RubricSpecificityGated,
+    RubricClinicalUtilityGated,
+    RubricTerminologyGated,
+
     // ---- Citation (deterministic + optional LLM support judge) ----
     CitationPresence,
     CitationValidity,
@@ -108,6 +122,11 @@ impl EvalMetric {
             RubricSpecificity,
             RubricClinicalUtility,
             RubricTerminology,
+            RubricRelevanceGated,
+            RubricCoherenceGated,
+            RubricSpecificityGated,
+            RubricClinicalUtilityGated,
+            RubricTerminologyGated,
             CitationPresence,
             CitationValidity,
             CitationScope,
@@ -153,12 +172,24 @@ mod tests {
         assert_eq!(EvalMetric::CitationValidity.as_str(), "citation_validity");
         assert_eq!(EvalMetric::CitationScope.as_str(), "citation_scope");
         assert_eq!(EvalMetric::CitationSupport.as_str(), "citation_support");
+        assert_eq!(
+            EvalMetric::RubricRelevanceGated.as_str(),
+            "rubric_relevance_gated"
+        );
+        assert_eq!(
+            EvalMetric::RubricClinicalUtilityGated.as_str(),
+            "rubric_clinical_utility_gated"
+        );
+        assert_eq!(
+            EvalMetric::RubricTerminologyGated.as_str(),
+            "rubric_terminology_gated"
+        );
     }
 
     #[test]
-    fn metric_all_covers_fifteen_metrics() {
-        // 11 legacy + 4 new citation metrics = 15.
-        assert_eq!(EvalMetric::all().len(), 15);
+    fn metric_all_covers_twenty_metrics() {
+        // 11 legacy + 4 citation + 5 gated rubric = 20.
+        assert_eq!(EvalMetric::all().len(), 20);
     }
 
     #[test]

--- a/evals-be/crates/infra/src/pg.rs
+++ b/evals-be/crates/infra/src/pg.rs
@@ -469,18 +469,18 @@ impl EvalsPostgresql {
                 }
 
                 let rows: Vec<Row> = diesel::sql_query(
-                    "SELECT rs.id
-                     FROM region_summary rs
-                     LEFT JOIN eval_runs er
-                            ON er.summary_id = rs.id AND er.eval_version = $1
-                     WHERE rs.summary IS NOT NULL
+                    "SELECT er.summary_id AS id
+                     FROM eval_runs er
+                     JOIN region_summary rs ON rs.id = er.summary_id
+                     WHERE er.eval_version = $1
+                       AND rs.summary IS NOT NULL
                        AND length(rs.summary) > 0
                        AND (
-                         er.id IS NULL
+                         er.status = 'queued'
                          OR er.status = 'failed'
                          OR (er.status = 'running' AND er.started_at < NOW() - INTERVAL '30 minutes')
                        )
-                     ORDER BY rs.created_at ASC NULLS FIRST
+                     ORDER BY er.created_at ASC
                      LIMIT $2",
                 )
                 .bind::<Text, _>(&ver)

--- a/evals-be/crates/rpc-types/src/lib.rs
+++ b/evals-be/crates/rpc-types/src/lib.rs
@@ -177,12 +177,13 @@ pub struct UnscoredResponse {
 
 // ---- POST /api/evals/batch ----
 
-/// Trigger eval runs for a list of summaries in the background.
+/// Queue eval runs for a list of summaries.
 ///
-/// Each `summary_id` gets its own independent `tokio::spawn`-ed eval task,
-/// identical to calling `POST /score/init` per ID. Repeated calls with
-/// overlapping IDs are intentional and each produce a fresh batch — no
-/// deduplication occurs.
+/// Each `summary_id` is marked `queued` in `eval_runs` for the effective eval
+/// version, and orch later picks it up via `/api/evals/unscored` to drive the
+/// full `init -> step -> ... -> done` loop. Repeated calls refresh the
+/// `(summary_id, eval_version)` row back to `queued` rather than spawning a
+/// second in-process worker.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BatchEvalRequest {
     /// One or more summary IDs to evaluate. Must be non-empty.

--- a/evals-be/crates/rpc-types/src/lib.rs
+++ b/evals-be/crates/rpc-types/src/lib.rs
@@ -175,6 +175,35 @@ pub struct UnscoredResponse {
     pub summary_ids: Vec<Uuid>,
 }
 
+// ---- POST /api/evals/batch ----
+
+/// Trigger eval runs for a list of summaries in the background.
+///
+/// Each `summary_id` gets its own independent `tokio::spawn`-ed eval task,
+/// identical to calling `POST /score/init` per ID. Repeated calls with
+/// overlapping IDs are intentional and each produce a fresh batch — no
+/// deduplication occurs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchEvalRequest {
+    /// One or more summary IDs to evaluate. Must be non-empty.
+    pub summary_ids: Vec<Uuid>,
+    /// Optional eval version override. Defaults to the server-configured
+    /// `EVAL_VERSION` env var when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eval_version: Option<String>,
+}
+
+/// Immediate response returned before any background eval task has completed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchEvalResponse {
+    /// Ephemeral correlation UUID generated server-side. Useful for log
+    /// correlation — not persisted and not queryable after this response.
+    pub batch_eval_id: Uuid,
+    /// Echo of every `summary_id` that was accepted into the background queue,
+    /// in the order they were received.
+    pub accepted: Vec<Uuid>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/evals-be/crates/services/Cargo.toml
+++ b/evals-be/crates/services/Cargo.toml
@@ -16,3 +16,4 @@ brainatlas-rpc-types.workspace = true
 rpc-types.workspace = true
 tokio.workspace = true
 regex.workspace = true
+strsim.workspace = true

--- a/evals-be/crates/services/src/infra.rs
+++ b/evals-be/crates/services/src/infra.rs
@@ -120,8 +120,12 @@ pub trait EvalsDatabase: Send + Sync {
         error_message: Option<String>,
     ) -> Result<EvalRun, Self::Error>;
 
-    /// Active summaries that have no `complete` run for the current
+    /// Summary IDs explicitly queued for evaluation for the given
     /// `eval_version`. Used by orch to find work.
+    ///
+    /// Only rows already present in `eval_runs` participate: `queued`
+    /// rows are normal work, and stale `running` rows are returned for
+    /// recovery after worker interruption.
     async fn list_unscored_summary_ids(
         &self,
         database_url: &str,

--- a/evals-be/crates/services/src/state_machine.rs
+++ b/evals-be/crates/services/src/state_machine.rs
@@ -2943,20 +2943,22 @@ mod advance_tests {
         assert!(!has_all_raw_rubric_metrics(&gated_only));
 
         let mut with_raw = gated_only.clone();
-        with_raw.extend([
-            EvalMetric::RubricRelevance,
-            EvalMetric::RubricCoherence,
-            EvalMetric::RubricSpecificity,
-            EvalMetric::RubricClinicalUtility,
-            EvalMetric::RubricTerminology,
-        ]
-        .into_iter()
-        .map(|metric| MetricResult {
-            metric: metric.as_str().to_string(),
-            score: 0.9,
-            cached: true,
-            judge_model: Some("rubric-model".to_string()),
-        }));
+        with_raw.extend(
+            [
+                EvalMetric::RubricRelevance,
+                EvalMetric::RubricCoherence,
+                EvalMetric::RubricSpecificity,
+                EvalMetric::RubricClinicalUtility,
+                EvalMetric::RubricTerminology,
+            ]
+            .into_iter()
+            .map(|metric| MetricResult {
+                metric: metric.as_str().to_string(),
+                score: 0.9,
+                cached: true,
+                judge_model: Some("rubric-model".to_string()),
+            }),
+        );
         assert!(has_all_raw_rubric_metrics(&with_raw));
     }
 

--- a/evals-be/crates/services/src/state_machine.rs
+++ b/evals-be/crates/services/src/state_machine.rs
@@ -618,8 +618,89 @@ where
         });
     }
 
+    // Gated rubric: `rubric_*_gated = rubric_* * claim_groundedness`. The
+    // rubric judge never sees source chunks, so it grades prose style on
+    // its own; multiplying by groundedness weights the rubric by how many
+    // claims are actually backed by evidence. Prevents the "confidently
+    // wrong" pattern (rubric ≥ 0.9 AND hallucination ≥ 0.5) from hiding in
+    // averages. Raw rubric rows are preserved above; these are additive.
+    persist_gated_rubric_metrics(db, database_url, ctx, &scores, accumulated).await?;
+
     // After rubric → hand off to the citation phase (if claims are available).
     next_citation_or_done(db, database_url, ctx, claims, accumulated).await
+}
+
+/// Persist the 5 `rubric_*_gated` derived metrics. Looks up the already-
+/// persisted `claim_groundedness` row for this summary; if it's missing
+/// (shouldn't happen in the normal flow — groundedness always runs before
+/// rubric) the gated rows are skipped so nothing blocks. No LLM cost.
+async fn persist_gated_rubric_metrics<DB, E>(
+    db: &DB,
+    database_url: &str,
+    ctx: &RunContext<'_>,
+    scores: &RubricScores,
+    accumulated: &mut Vec<MetricResult>,
+) -> Result<(), ServiceError<E>>
+where
+    DB: EvalsDatabase<Error = E>,
+    E: Error + Send + Sync + 'static,
+{
+    let groundedness_row = db
+        .lookup_score_by_hash(
+            database_url,
+            ctx.summary_hash,
+            EvalMetric::ClaimGroundedness.as_str(),
+            ctx.eval_version,
+        )
+        .await
+        .map_err(ServiceError::InfraError)?;
+    let Some(groundedness_row) = groundedness_row else {
+        // Groundedness not persisted yet; can't gate. Skip silently — the
+        // gated rows will be produced on the next eval run once
+        // groundedness lands.
+        return Ok(());
+    };
+    let g = groundedness_row.score;
+
+    for (metric, crit) in [
+        (EvalMetric::RubricRelevanceGated, &scores.relevance),
+        (EvalMetric::RubricCoherenceGated, &scores.coherence),
+        (EvalMetric::RubricSpecificityGated, &scores.specificity),
+        (EvalMetric::RubricClinicalUtilityGated, &scores.clinical_utility),
+        (EvalMetric::RubricTerminologyGated, &scores.terminology),
+    ] {
+        let raw = normalise_1_to_5(crit.score);
+        let gated = raw * g;
+        let details = serde_json::json!({
+            "raw_rubric_score": raw,
+            "claim_groundedness": g,
+            "gated_formula": "rubric * claim_groundedness",
+        });
+        let res = score_with_cache(
+            db,
+            database_url,
+            ctx.summary.id,
+            ctx.summary_hash,
+            metric.as_str(),
+            ctx.eval_version,
+            || async {
+                Ok(ComputedScore {
+                    score: gated,
+                    // Derived metric — not produced by an LLM.
+                    judge_model: None,
+                    details: Some(details.clone()),
+                })
+            },
+        )
+        .await?;
+        accumulated.push(MetricResult {
+            metric: res.row.metric,
+            score: res.row.score,
+            cached: res.cached,
+            judge_model: res.row.judge_model,
+        });
+    }
+    Ok(())
 }
 
 // ---- helpers ----
@@ -2363,6 +2444,138 @@ mod advance_tests {
         // No claims → citations skipped, Done.
         assert!(matches!(state, RunState::Done));
         assert!(matches!(next, NextAction::Done { .. }));
+    }
+
+    /// With `claim_groundedness` already persisted at `g = 0.5`, rubric should
+    /// emit 5 raw rubric_* rows AND 5 `rubric_*_gated` rows where each gated
+    /// value equals `raw * 0.5`. This locks Fix C1: the gating math.
+    #[tokio::test]
+    async fn advance_rubric_emits_gated_metrics_when_groundedness_present() {
+        let summary = fixture_summary();
+        let db = InMemoryDb::new();
+        let ctx = ctx_for(&summary, "hash-rubric-gated");
+
+        // Seed claim_groundedness = 0.5 into the cache before rubric runs.
+        db.insert_score(
+            "memory://",
+            NewEvalScore {
+                summary_id: summary.id,
+                summary_hash: ctx.summary_hash.to_string(),
+                metric: EvalMetric::ClaimGroundedness.as_str().to_string(),
+                score: 0.5,
+                judge_model: Some("mock-judge".to_string()),
+                details: None,
+                eval_version: ctx.eval_version.to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let c = |s: u8| RubricCriterion {
+            score: s,
+            rationale: "r".into(),
+        };
+        // score=5 → normalised 1.0; score=3 → 0.5; score=1 → 0.0.
+        let response = LlmResponsePayload::Rubric(RubricScores {
+            relevance: c(5),
+            coherence: c(4),
+            specificity: c(3),
+            clinical_utility: c(2),
+            terminology: c(1),
+        });
+        let mut acc = Vec::new();
+        let (_state, _next) = advance_rubric(&db, "memory://", &ctx, response, None, &mut acc)
+            .await
+            .expect("rubric");
+
+        // Raw + gated = 10 rubric rows in the accumulator.
+        let rubric_rows: Vec<_> = acc
+            .iter()
+            .filter(|m| m.metric.starts_with("rubric_"))
+            .collect();
+        assert_eq!(
+            rubric_rows.len(),
+            10,
+            "expected 5 raw + 5 gated rubric rows, got {rubric_rows:?}"
+        );
+
+        // Locking the math: rubric_relevance = 1.0, gated = 0.5.
+        let raw_rel = acc.iter().find(|m| m.metric == "rubric_relevance").unwrap();
+        let gated_rel = acc
+            .iter()
+            .find(|m| m.metric == "rubric_relevance_gated")
+            .unwrap();
+        assert!((raw_rel.score - 1.0).abs() < 1e-6);
+        assert!(
+            (gated_rel.score - 0.5).abs() < 1e-6,
+            "rubric_relevance_gated expected 0.5, got {}",
+            gated_rel.score
+        );
+
+        // rubric_terminology = 0.0, gated = 0.0 (not NaN).
+        let raw_term = acc
+            .iter()
+            .find(|m| m.metric == "rubric_terminology")
+            .unwrap();
+        let gated_term = acc
+            .iter()
+            .find(|m| m.metric == "rubric_terminology_gated")
+            .unwrap();
+        assert!((raw_term.score - 0.0).abs() < 1e-6);
+        assert!((gated_term.score - 0.0).abs() < 1e-6);
+
+        // rubric_specificity = 0.5, gated = 0.25.
+        let gated_spec = acc
+            .iter()
+            .find(|m| m.metric == "rubric_specificity_gated")
+            .unwrap();
+        assert!(
+            (gated_spec.score - 0.25).abs() < 1e-6,
+            "rubric_specificity_gated expected 0.25, got {}",
+            gated_spec.score
+        );
+
+        // Gated rows must have judge_model = None (derived, no LLM).
+        assert!(gated_rel.judge_model.is_none());
+        assert!(gated_term.judge_model.is_none());
+    }
+
+    /// Defensive: if `claim_groundedness` is absent from cache, `advance_rubric`
+    /// must still emit the 5 raw rubric rows and NOT emit any gated rows (they
+    /// will be produced on the next eval run once groundedness lands). Locks
+    /// the silent-skip fallback in `persist_gated_rubric_metrics`.
+    #[tokio::test]
+    async fn advance_rubric_skips_gated_when_groundedness_missing() {
+        let summary = fixture_summary();
+        let db = InMemoryDb::new(); // no groundedness seeded
+        let ctx = ctx_for(&summary, "hash-rubric-nogrounded");
+        let mut acc = Vec::new();
+
+        let c = |s: u8| RubricCriterion {
+            score: s,
+            rationale: "r".into(),
+        };
+        let response = LlmResponsePayload::Rubric(RubricScores {
+            relevance: c(5),
+            coherence: c(5),
+            specificity: c(5),
+            clinical_utility: c(5),
+            terminology: c(5),
+        });
+        let (_state, _next) = advance_rubric(&db, "memory://", &ctx, response, None, &mut acc)
+            .await
+            .expect("rubric");
+
+        let raw_count = acc
+            .iter()
+            .filter(|m| m.metric.starts_with("rubric_") && !m.metric.ends_with("_gated"))
+            .count();
+        let gated_count = acc
+            .iter()
+            .filter(|m| m.metric.ends_with("_gated"))
+            .count();
+        assert_eq!(raw_count, 5);
+        assert_eq!(gated_count, 0);
     }
 
     /// Cached-rubric-but-fresh-groundedness path (TODO at :622-644): when all

--- a/evals-be/crates/services/src/state_machine.rs
+++ b/evals-be/crates/services/src/state_machine.rs
@@ -666,7 +666,10 @@ where
         (EvalMetric::RubricRelevanceGated, &scores.relevance),
         (EvalMetric::RubricCoherenceGated, &scores.coherence),
         (EvalMetric::RubricSpecificityGated, &scores.specificity),
-        (EvalMetric::RubricClinicalUtilityGated, &scores.clinical_utility),
+        (
+            EvalMetric::RubricClinicalUtilityGated,
+            &scores.clinical_utility,
+        ),
         (EvalMetric::RubricTerminologyGated, &scores.terminology),
     ] {
         let raw = normalise_1_to_5(crit.score);
@@ -2570,10 +2573,7 @@ mod advance_tests {
             .iter()
             .filter(|m| m.metric.starts_with("rubric_") && !m.metric.ends_with("_gated"))
             .count();
-        let gated_count = acc
-            .iter()
-            .filter(|m| m.metric.ends_with("_gated"))
-            .count();
+        let gated_count = acc.iter().filter(|m| m.metric.ends_with("_gated")).count();
         assert_eq!(raw_count, 5);
         assert_eq!(gated_count, 0);
     }

--- a/evals-be/crates/services/src/state_machine.rs
+++ b/evals-be/crates/services/src/state_machine.rs
@@ -740,17 +740,30 @@ fn start_embed_step<E: Error + Send + Sync + 'static>(
     ))
 }
 
+fn has_all_raw_rubric_metrics(accumulated: &[MetricResult]) -> bool {
+    use EvalMetric::{
+        RubricClinicalUtility, RubricCoherence, RubricRelevance, RubricSpecificity,
+        RubricTerminology,
+    };
+
+    [
+        RubricRelevance.as_str(),
+        RubricCoherence.as_str(),
+        RubricSpecificity.as_str(),
+        RubricClinicalUtility.as_str(),
+        RubricTerminology.as_str(),
+    ]
+    .into_iter()
+    .all(|metric| accumulated.iter().any(|m| m.metric == metric))
+}
+
 /// Either kick off the rubric step, or emit Done if rubric is cached.
 fn next_rubric_or_done(
     ctx: &RunContext<'_>,
     claims: Option<Vec<Claim>>,
     accumulated: &mut [MetricResult],
 ) -> (RunState, NextAction) {
-    let already_cached_rubric = accumulated
-        .iter()
-        .filter(|m| m.metric.starts_with("rubric_"))
-        .count()
-        == 5;
+    let already_cached_rubric = has_all_raw_rubric_metrics(accumulated);
     if already_cached_rubric {
         // Rubric already cached — the caller must still run citations.
         // But `next_rubric_or_done` is sync and citations need DB access,
@@ -2888,6 +2901,63 @@ mod advance_tests {
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0]["kind"], "unsupported");
         assert_eq!(issues[0]["claim_id"], 7);
+    }
+
+    /// Raw rubric cache detection must key off the exact five ungated metric
+    /// names, not every `rubric_*` metric. Gated rubric rows are additive and
+    /// must not short-circuit the raw rubric phase on their own.
+    #[test]
+    fn has_all_raw_rubric_metrics_ignores_gated_rows() {
+        let gated_only = vec![
+            MetricResult {
+                metric: EvalMetric::RubricRelevanceGated.as_str().to_string(),
+                score: 0.2,
+                cached: true,
+                judge_model: None,
+            },
+            MetricResult {
+                metric: EvalMetric::RubricCoherenceGated.as_str().to_string(),
+                score: 0.2,
+                cached: true,
+                judge_model: None,
+            },
+            MetricResult {
+                metric: EvalMetric::RubricSpecificityGated.as_str().to_string(),
+                score: 0.2,
+                cached: true,
+                judge_model: None,
+            },
+            MetricResult {
+                metric: EvalMetric::RubricClinicalUtilityGated.as_str().to_string(),
+                score: 0.2,
+                cached: true,
+                judge_model: None,
+            },
+            MetricResult {
+                metric: EvalMetric::RubricTerminologyGated.as_str().to_string(),
+                score: 0.2,
+                cached: true,
+                judge_model: None,
+            },
+        ];
+        assert!(!has_all_raw_rubric_metrics(&gated_only));
+
+        let mut with_raw = gated_only.clone();
+        with_raw.extend([
+            EvalMetric::RubricRelevance,
+            EvalMetric::RubricCoherence,
+            EvalMetric::RubricSpecificity,
+            EvalMetric::RubricClinicalUtility,
+            EvalMetric::RubricTerminology,
+        ]
+        .into_iter()
+        .map(|metric| MetricResult {
+            metric: metric.as_str().to_string(),
+            score: 0.9,
+            cached: true,
+            judge_model: Some("rubric-model".to_string()),
+        }));
+        assert!(has_all_raw_rubric_metrics(&with_raw));
     }
 
     // ---- find_next_support_step iteration ----

--- a/evals-be/crates/services/src/structural.rs
+++ b/evals-be/crates/services/src/structural.rs
@@ -94,9 +94,10 @@ pub fn acronym_mention(summary: &str, acronym: Option<&str>) -> f32 {
                     .collect::<Vec<_>>()
                     .join("[.\\-]?");
                 if let Ok(re) = regex::Regex::new(&format!("(?i){dotted}"))
-                    && re.is_match(summary) {
-                        return 1.0;
-                    }
+                    && re.is_match(summary)
+                {
+                    return 1.0;
+                }
             }
 
             // 3. Fuzzy word-level match via Levenshtein distance.

--- a/evals-be/crates/services/src/structural.rs
+++ b/evals-be/crates/services/src/structural.rs
@@ -93,11 +93,10 @@ pub fn acronym_mention(summary: &str, acronym: Option<&str>) -> f32 {
                     .map(|c| c.to_string())
                     .collect::<Vec<_>>()
                     .join("[.\\-]?");
-                if let Ok(re) = regex::Regex::new(&format!("(?i){dotted}")) {
-                    if re.is_match(summary) {
+                if let Ok(re) = regex::Regex::new(&format!("(?i){dotted}"))
+                    && re.is_match(summary) {
                         return 1.0;
                     }
-                }
             }
 
             // 3. Fuzzy word-level match via Levenshtein distance.

--- a/evals-be/crates/services/src/structural.rs
+++ b/evals-be/crates/services/src/structural.rs
@@ -61,18 +61,66 @@ pub fn length_in_range(summary: &str) -> f32 {
     1.0 - ((len as f32 - LENGTH_HIGH as f32) / (LENGTH_CEIL as f32 - LENGTH_HIGH as f32))
 }
 
-/// 1.0 if the acronym appears at least once in the summary text, else 0.0.
-/// If `acronym` is `None` (regions without one) this is vacuously 1.0.
+/// Score for acronym presence in the summary text.
+///
+/// Matching strategy (first match wins, highest score returned):
+///  1. **Exact substring** (case-insensitive) → `1.0`
+///  2. **Dotted / hyphenated form** — e.g. `HPC` matches `H.P.C.` or `H-P-C` → `1.0`
+///  3. **Fuzzy word match** — any whitespace-delimited token within Levenshtein
+///     distance ≤ `max(1, acronym.len() / 3)` of the acronym → `0.5`
+///
+/// If `acronym` is `None` or blank, returns `1.0` (vacuously satisfied).
 pub fn acronym_mention(summary: &str, acronym: Option<&str>) -> f32 {
     match acronym {
         None => 1.0,
-        Some(a) if a.trim().is_empty() => 1.0,
         Some(a) => {
-            if summary.contains(a) {
-                1.0
-            } else {
-                0.0
+            let a = a.trim();
+            if a.is_empty() {
+                return 1.0;
             }
+            let summary_lower = summary.to_ascii_lowercase();
+            let acronym_lower = a.to_ascii_lowercase();
+
+            // 1. Exact case-insensitive substring.
+            if summary_lower.contains(&acronym_lower) {
+                return 1.0;
+            }
+
+            // 2. Dotted / hyphenated form (e.g. "H.P.C." or "H-P-C" for "HPC").
+            if acronym_lower.len() >= 2 {
+                let dotted: String = acronym_lower
+                    .chars()
+                    .map(|c| c.to_string())
+                    .collect::<Vec<_>>()
+                    .join("[.\\-]?");
+                if let Ok(re) = regex::Regex::new(&format!("(?i){dotted}")) {
+                    if re.is_match(summary) {
+                        return 1.0;
+                    }
+                }
+            }
+
+            // 3. Fuzzy word-level match via Levenshtein distance.
+            let max_dist = (acronym_lower.len() / 3).max(1);
+            for token in summary_lower.split_whitespace() {
+                // Strip common trailing punctuation so "HPC," or "(HPC)" don't
+                // inflate edit distance.
+                let token = token.trim_matches(|c: char| !c.is_alphanumeric());
+                if token.is_empty() {
+                    continue;
+                }
+                // Skip tokens whose length differs too much — they can never be
+                // within `max_dist`.
+                let len_diff = token.len().abs_diff(acronym_lower.len());
+                if len_diff > max_dist {
+                    continue;
+                }
+                if strsim::levenshtein(token, &acronym_lower) <= max_dist {
+                    return 0.5;
+                }
+            }
+
+            0.0
         }
     }
 }
@@ -165,6 +213,69 @@ mod tests {
         assert_eq!(
             acronym_mention("The HPC supports memory.", Some("HPC")),
             1.0
+        );
+    }
+
+    #[test]
+    fn acronym_mention_case_insensitive() {
+        assert_eq!(
+            acronym_mention("The hpc supports memory.", Some("HPC")),
+            1.0
+        );
+        assert_eq!(
+            acronym_mention("The HPC supports memory.", Some("hpc")),
+            1.0
+        );
+    }
+
+    #[test]
+    fn acronym_mention_trims_whitespace() {
+        assert_eq!(
+            acronym_mention("The HPC supports memory.", Some(" HPC ")),
+            1.0
+        );
+        assert_eq!(
+            acronym_mention("The HPC supports memory.", Some("  HPC\t")),
+            1.0
+        );
+    }
+
+    #[test]
+    fn acronym_mention_dotted_form() {
+        assert_eq!(
+            acronym_mention("The H.P.C. supports memory.", Some("HPC")),
+            1.0
+        );
+        assert_eq!(
+            acronym_mention("The H-P-C supports memory.", Some("HPC")),
+            1.0
+        );
+    }
+
+    #[test]
+    fn acronym_mention_fuzzy_one_char_off() {
+        // "HPC" vs "HRC" — edit distance 1, within threshold max(1, 3/3)=1
+        assert_eq!(
+            acronym_mention("The HRC supports memory.", Some("HPC")),
+            0.5
+        );
+    }
+
+    #[test]
+    fn acronym_mention_fuzzy_too_distant() {
+        // "HPC" vs "XYZ" — edit distance 3, exceeds threshold
+        assert_eq!(
+            acronym_mention("The XYZ supports memory.", Some("HPC")),
+            0.0
+        );
+    }
+
+    #[test]
+    fn acronym_mention_fuzzy_with_punctuation() {
+        // Token "(HRC)" should be stripped to "HRC" then fuzzy-matched
+        assert_eq!(
+            acronym_mention("The (HRC) supports memory.", Some("HPC")),
+            0.5
         );
     }
 

--- a/orch/crates/server/src/dev_stats.html
+++ b/orch/crates/server/src/dev_stats.html
@@ -172,6 +172,32 @@
 
   .error-msg { color: var(--red); font-size: 0.8rem; padding: 0.5rem; }
 
+  .input-label {
+    display: block;
+    font-size: 0.78rem;
+    color: var(--text-dim);
+    margin-bottom: 0.35rem;
+  }
+  .text-input, .text-area {
+    width: 100%;
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text);
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    padding: 0.55rem 0.7rem;
+  }
+  .text-input:focus, .text-area:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .text-area {
+    min-height: 110px;
+    resize: vertical;
+    line-height: 1.45;
+  }
+
   /* tooltips */
   [data-tip] {
     position: relative;
@@ -353,6 +379,20 @@
     <h2>Evals <span style="font-weight: normal; font-size: 0.8rem; color: var(--text-dim); margin-left: 0.5rem;" data-tip="Phase-4 quality evaluation: structural metrics + LLM-judged groundedness/rubric over generated region summaries.">automated quality scoring</span></h2>
     <div id="evalStatus" style="margin-bottom: 0.8rem"></div>
     <div class="stat-row" id="evalOverview" style="margin-bottom: 0.8rem"></div>
+    <h3 style="margin-top: 1rem; font-size: 1rem;">Batch queue <span style="font-weight: normal; font-size: 0.8rem; color: var(--text-dim);" data-tip="Posts to /api/evals/batch. Each summary ID is marked queued and the eval orchestrator later drains it via the unscored route.">enqueue eval runs</span></h3>
+    <div style="display: grid; grid-template-columns: minmax(260px, 1fr) minmax(180px, 260px); gap: 0.9rem; margin-top: 0.7rem; align-items: start;">
+      <div>
+        <label class="input-label" for="evalBatchIds">Summary IDs <span style="color: var(--text-dim);">(one UUID per line, comma-separated also works)</span></label>
+        <textarea id="evalBatchIds" class="text-area" spellcheck="false" placeholder="11111111-1111-1111-1111-111111111111&#10;22222222-2222-2222-2222-222222222222"></textarea>
+      </div>
+      <div>
+        <label class="input-label" for="evalBatchVersion">Eval version override <span style="color: var(--text-dim);">(optional)</span></label>
+        <input id="evalBatchVersion" class="text-input" type="text" spellcheck="false" placeholder="v-batch">
+        <button id="evalBatchBtn" style="margin-top: 0.9rem; width: 100%; padding: 0.65rem 1rem; background: var(--accent); color: white; border: none; border-radius: 6px; cursor: pointer; font-weight: 600;">Queue Eval Batch</button>
+        <div style="margin-top: 0.6rem; font-size: 0.76rem; color: var(--text-dim);" data-tip="This only queues eval_runs rows. It does not synchronously execute scoring in the browser request.">Returns HTTP 202 on success.</div>
+      </div>
+    </div>
+    <div id="evalBatchResult" style="margin-top: 0.8rem; font-family: var(--mono); font-size: 0.8rem; color: var(--text-dim); white-space: pre-wrap; display: none;"></div>
     <h3 style="margin-top: 1rem; font-size: 1rem;">Worst offenders by groundedness <span style="font-weight: normal; font-size: 0.8rem; color: var(--text-dim);" data-tip="Lowest groundedness scores: indicates summaries with claims poorly supported by retrieved chunks.">(top 10)</span></h3>
     <div id="evalWorst" style="overflow-x:auto"></div>
   </div>
@@ -567,6 +607,16 @@ function renderQueryDist(items) {
   $('queryDist').innerHTML = html;
 }
 
+function parseUuidList(raw) {
+  if (!raw) return [];
+  return [...new Set(
+    raw
+      .split(/[\s,]+/)
+      .map(s => s.trim())
+      .filter(Boolean)
+  )];
+}
+
 async function safeFetch(url) {
   try {
     const r = await fetch(url);
@@ -757,6 +807,58 @@ $('triggerBtn').addEventListener('click', async () => {
   } finally {
     btn.disabled = false;
     btn.textContent = 'Trigger Pipeline';
+  }
+});
+
+// Eval batch trigger button
+$('evalBatchBtn').addEventListener('click', async () => {
+  const ids = parseUuidList($('evalBatchIds').value);
+  const evalVersionRaw = $('evalBatchVersion').value.trim();
+  const out = $('evalBatchResult');
+  const btn = $('evalBatchBtn');
+
+  if (ids.length === 0) {
+    out.style.display = 'block';
+    out.style.color = 'var(--red)';
+    out.textContent = 'Provide at least one summary UUID.';
+    return;
+  }
+
+  const body = {
+    summary_ids: ids,
+    ...(evalVersionRaw ? { eval_version: evalVersionRaw } : {})
+  };
+
+  btn.disabled = true;
+  btn.textContent = 'Queueing...';
+  out.style.display = 'block';
+  out.style.color = 'var(--text-dim)';
+  out.textContent = 'POST ' + BASE + '/api/evals/batch\n' + JSON.stringify(body, null, 2);
+
+  try {
+    const res = await fetch(BASE + '/api/evals/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    const text = await res.text();
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+    out.style.color = res.ok ? 'var(--accent)' : 'var(--red)';
+    out.textContent = 'HTTP ' + res.status + '\n' + (typeof parsed === 'string' ? parsed : JSON.stringify(parsed, null, 2));
+    if (res.ok) {
+      poll();
+    }
+  } catch (e) {
+    out.style.color = 'var(--red)';
+    out.textContent = 'Error: ' + e.message;
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Queue Eval Batch';
   }
 });
 

--- a/orch/crates/services/src/eval_orchestrator.rs
+++ b/orch/crates/services/src/eval_orchestrator.rs
@@ -214,7 +214,7 @@ where
     async fn eval_version(&self) -> String {
         self.get_config_string(ConfigKey::EvalVersion)
             .await
-            .unwrap_or_else(|| "v0.2.0".to_string())
+            .unwrap_or_else(|| "v0.4.0".to_string())
     }
 
     pub async fn is_enabled(&self) -> bool {

--- a/orch/migrations/2026-04-19-000001-add_eval_config/up.sql
+++ b/orch/migrations/2026-04-19-000001-add_eval_config/up.sql
@@ -7,5 +7,5 @@ INSERT INTO orch_config (key, value, description) VALUES
     ('eval_orchestrator_poll_interval_secs', '60',  'Poll cadence for the eval orchestrator'),
     ('eval_orchestrator_concurrency',        '5',   'Max parallel POST /evals-be/api/evals/score calls'),
     ('evals_base_url',          'http://evals-be:8083', 'Base URL for evals-be'),
-    ('eval_version',                       'v0.2.0',  'Cache version forwarded to evals-be on every score request')
+    ('eval_version',                       'v0.4.0',  'Cache version forwarded to evals-be on every score request')
 ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary
Add background batch evaluation for multiple summaries while tightening eval scoring so cache hits include groundedness-gated rubric metrics and acronym detection is more tolerant of real-world formatting.

## Context
The evals service already supported single-summary scoring, but there was no way to enqueue multiple summaries for background processing from one request. At the same time, raw rubric scores could make factually weak summaries look stronger than they should, and cache-hit responses were not surfacing the derived gated rubric rows. Structural acronym checks were also brittle for common formats like dotted acronyms, case differences, and minor OCR-style typos.

## Changes
- Added a new batch eval API that accepts multiple summary IDs and starts background scoring tasks for each one.
- Introduced `BatchEvalRequest` / `BatchEvalResponse` wire types and exposed the new route through the evals API facade and router.
- Added five derived `rubric_*_gated` metrics and included them in the canonical metric set, cache probing, and final score responses.
- Persisted gated rubric metrics after rubric scoring by multiplying each normalized rubric score by `claim_groundedness`.
- Bumped the default eval cache version to `v0.4.0` so the new metric set can be recomputed cleanly.
- Made structural acronym matching more robust with case-insensitive, dotted/hyphenated, and fuzzy token matching.
- Expanded tests to lock the new metric counts and the gated-rubric math.

### Key Implementation Details
- `batch_eval` now returns immediately with HTTP 202 and a correlation UUID, while each summary is processed in its own spawned task via the existing `init_score` flow.
- Gated rubric metrics are derived with the formula `raw_rubric_score * claim_groundedness`, stored without a judge model, and include details describing the formula inputs.
- Cache probing remains authoritative on the raw rubric rows, but it now additively surfaces any already-persisted gated rubric rows so full cache-hit responses return the complete metric set.
- The rubric prompt now includes a factual-accuracy guardrail that caps several rubric dimensions when summaries make obvious neuroanatomy mistakes.
- Acronym matching uses exact case-insensitive matches first, then dotted/hyphenated variants, then bounded Levenshtein-distance fuzzy matches for near misses.

## Use Cases
- Kick off scoring for a batch of summary IDs from an orchestrator without issuing one HTTP request per summary.
- Prevent polished but weakly grounded summaries from appearing too strong in aggregate rubric dashboards.
- Return a consistent, fully populated metric list on cache hits, including gated rubric rows.
- Better score summaries that mention region acronyms in formats like `H.P.C.`, `H-P-C`, lowercase, or slightly noisy tokens.

## Testing
```bash
cargo test --manifest-path evals-be/Cargo.toml
```

## Links
- PR: https://github.com/CortexMap/cortexmap/pull/73
